### PR TITLE
Remove unused variables from wordTranslation and PhraseTranslation

### DIFF
--- a/src/main/java/com/antonio/apprendrebackend/service/dto/WordTranslationDTO.java
+++ b/src/main/java/com/antonio/apprendrebackend/service/dto/WordTranslationDTO.java
@@ -2,26 +2,17 @@ package com.antonio.apprendrebackend.service.dto;
 
 
 import com.antonio.apprendrebackend.service.model.Language;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class WordTranslationDTO {
     private Integer id;
     private WordSenseDTO wordSenseFr;
     private WordSenseDTO wordSenseSp;
-    private Integer attempts;
-    private Integer successes;
-
-    public WordTranslationDTO() {
-    }
-
-    public WordTranslationDTO(Integer id, WordSenseDTO wordSenseFr, WordSenseDTO wordSenseSp, Integer attempts, Integer successes) {
-        this.id = id;
-        this.wordSenseFr = wordSenseFr;
-        this.wordSenseSp = wordSenseSp;
-        this.attempts = attempts;
-        this.successes = successes;
-    }
 }

--- a/src/main/java/com/antonio/apprendrebackend/service/mapper/WordTranslationMapper.java
+++ b/src/main/java/com/antonio/apprendrebackend/service/mapper/WordTranslationMapper.java
@@ -11,14 +11,10 @@ import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
 public interface WordTranslationMapper {
-
     WordTranslationMapper INSTANCE = Mappers.getMapper(WordTranslationMapper.class);
-
 
     @Mapping(target = "id", source = "id")
     @Mapping(target = "wordSenseFr", source = "wordSenseFr")
     @Mapping(target = "wordSenseSp", source = "wordSenseSp")
-    @Mapping(target = "attempts", source = "attempts")
-    @Mapping(target = "successes", source = "successes")
     WordTranslationDTO toDTO(WordTranslation wordTranslation);
 }

--- a/src/main/java/com/antonio/apprendrebackend/service/model/PhraseTranslation.java
+++ b/src/main/java/com/antonio/apprendrebackend/service/model/PhraseTranslation.java
@@ -21,6 +21,4 @@ public class PhraseTranslation {
     private Phrase phraseSp;
 
     private String description;
-    private Integer attempts;
-    private Integer successes;
 }

--- a/src/main/java/com/antonio/apprendrebackend/service/model/WordTranslation.java
+++ b/src/main/java/com/antonio/apprendrebackend/service/model/WordTranslation.java
@@ -28,20 +28,10 @@ public class WordTranslation {
     @JoinColumn(name = "conjugation_verb_form_id")
     private ConjugationVerbForm conjugationVerbForm;
 
-    private Integer attempts;
-    private Integer successes;
     private Integer importanceIndex;
-
-
-    public WordTranslation() {
-        this.attempts = 0;
-        this.successes = 0;
-    }
 
     public WordTranslation(WordSense wordSenseFr, WordSense wordSenseSp) {
         this.wordSenseFr = wordSenseFr;
         this.wordSenseSp = wordSenseSp;
-        this.attempts = 0;
-        this.successes = 0;
     }
 }


### PR DESCRIPTION
The variales successes and attempts has been removed from wordTranslation and PhraseTrasnlation, while this data is saved in deckWOrdPhraseTrasnaltion